### PR TITLE
refactor: 重構service載入的方式

### DIFF
--- a/app/controller/demo.js
+++ b/app/controller/demo.js
@@ -1,7 +1,7 @@
 module.exports = async (ctx) => {
   ctx.body = ctx.locals;
   ctx.body += `\nctx.service.demo.test() - ${await ctx.service.demo.test()}`;
-  ctx.body += `\nctx.service.demo2.test() - ${await ctx.service.demo2.test()}`;
-  ctx.body += `\nctx.service.demo3() - ${await ctx.service.demo3()}`;
-  ctx.body += `\nctx.service.demo4.demo4.test() - ${await ctx.service.demo4.demo4.test()}`;
+  ctx.body += `\nctx.service.demo2() - ${await ctx.service.demo2()}`;
+  ctx.body += `\nctx.service.demo3.demo4.test() - ${await ctx.service.demo3.demo4.test()}`;
+  ctx.body += `\nctx.service.demo3.demo4.test2() - ${await ctx.service.demo3.demo4.test2()}`;
 };

--- a/app/service/demo2.js
+++ b/app/service/demo2.js
@@ -1,6 +1,5 @@
-module.exports = (ctx) => {
-  const test = async () => `${ctx.originalUrl} - this service returns an object which defines functions`;
-  return {
-    test,
-  };
+module.exports = function onlyFunction() {
+  const { ctx } = this;
+  if (ctx) return `${ctx.originalUrl} - this service is simply a function`;
+  return 'this service is simply a function and no ctx';
 };

--- a/app/service/demo3.js
+++ b/app/service/demo3.js
@@ -1,4 +1,0 @@
-module.exports = (ctx) => {
-  const test = async () => `${ctx.originalUrl} - this service is simply a function`;
-  return test;
-};

--- a/app/service/demo3/demo4.js
+++ b/app/service/demo3/demo4.js
@@ -1,0 +1,7 @@
+module.exports = {
+  test: async () => 'arrow functions can\'t access ctx',
+
+  async test2() {
+    return `${this.ctx.originalUrl} - simply function and can access ctx`;
+  },
+};

--- a/app/service/demo4/demo4.js
+++ b/app/service/demo4/demo4.js
@@ -1,3 +1,0 @@
-module.exports = {
-  test: async () => 'this service is only an object, can not access ctx',
-};

--- a/lib/app.js
+++ b/lib/app.js
@@ -40,9 +40,7 @@ const router = new Router();
 app.router = router;
 app.controller = {};
 app.middlewares = {};
-app.service = {};
-app.model = {};
-app.serviceClasses = {};
+app.serviceClasses = new Map();
 
 // 將app放置到global裡，以方便單獨使用
 global.app = app;

--- a/lib/class/base_context_class.js
+++ b/lib/class/base_context_class.js
@@ -1,5 +1,14 @@
+// 判斷要載入的module是否為Class
+const typeofModule = (module) => {
+  if (typeof module === 'function') {
+    if (/^class\s/.test(Function.prototype.toString.call(module))) return 'class';
+    return 'function';
+  }
+  return 'object';
+};
+
 class BaseContextClass {
-  constructor(ctx) {
+  constructor(ctx, subModules = new Map()) {
     const { app } = global;
     if (ctx) {
       this.ctx = ctx;
@@ -8,6 +17,81 @@ class BaseContextClass {
     }
     this.app = this.ctx.app;
     this.config = this.app.config;
+
+    // 儲存instance的暫存，以nameSpace為key值儲存instance
+    // 確保每個ctx階段不會產生兩個同樣的instance
+    this.instanceCache = new Map();
+
+    // 建立一個變數來儲存此module以下是否仍然有巢狀結構的sub modules
+    const subModuleMap = new Map();
+
+    // 掃描sub module
+    subModules.forEach((value, key) => {
+      // 取得下一個sub module的第一個namespace
+      const subName = key.split('.')[0];
+      // 從傳入的subModules裡判斷此namespace是否為已經載入的模組
+      // 如果沒有被載入的模組，那就表示此namespace之下仍然有巢狀的結構
+      // 則將巢狀結構儲存到subModuleMap裡，繼續往下傳遞到下一個 BaseContextClass
+      const Loaded = subModules.get(subName);
+      if (!Loaded) {
+        const mapItem = subModuleMap.get(subName) || new Map();
+        mapItem.set(key.replace(`${subName}.`, ''), subModules.get(key));
+        subModuleMap.set(subName, mapItem);
+        return;
+      }
+
+      // 判斷載入的模組是屬於class/function/object
+      const moduleTypeof = typeofModule(Loaded);
+
+      // 如果是class，則給予getter
+      if (moduleTypeof === 'class') {
+        Object.defineProperty(this, subName, {
+          get() {
+            // 確定是否有cache，有則回傳cache
+            if (this.instanceCache.get(subName)) return this.instanceCache.get(subName);
+            const instance = new Loaded(ctx);
+            this.instanceCache.set(subName, instance);
+            return instance;
+          },
+        });
+      }
+
+      // 如果是function，直接將這個function binding到this
+      if (moduleTypeof === 'function') {
+        this[subName] = Loaded.bind(this);
+      }
+
+      // 如果是一個object，就給予一個getter，用來產生新的BaseContextClass，
+      // 並將此object裡的function/properties賦予給新的instance
+      if (moduleTypeof === 'object') {
+        Object.defineProperty(this, subName, {
+          get() {
+            if (this.instanceCache.get(subName)) return this.instanceCache.get(subName);
+            const instance = new BaseContextClass(ctx);
+            this.instanceCache.set(subName, instance);
+
+            const properties = Object.getOwnPropertyNames(Loaded);
+            properties.forEach((v1) => {
+              const descriptor = Object.getOwnPropertyDescriptor(Loaded, v1);
+              Object.defineProperty(instance, v1, descriptor);
+            });
+            return instance;
+          },
+        });
+      }
+    });
+
+    // 建立巢狀子服務的getter
+    subModuleMap.forEach((value, key) => {
+      Object.defineProperty(this, key, {
+        get() {
+          if (this.instanceCache.get(key)) return this.instanceCache.get(key);
+          const instance = new BaseContextClass(ctx, subModuleMap.get(key));
+          this.instanceCache.set(key, instance);
+          return instance;
+        },
+      });
+    });
   }
 }
 

--- a/lib/loader/service_loader.js
+++ b/lib/loader/service_loader.js
@@ -5,73 +5,22 @@ const path = require('path');
 const async = require('async');
 const toCamelCase = require('../to_camel_case');
 
-// 判斷要載入的service是否為Class
-const typeofService = (service) => {
-  if (typeof service === 'function') {
-    if (service.prototype && service.prototype.constructor) {
-      return 'class';
-    }
-    return 'function';
-  }
-  return 'object';
-};
-
-const serviceGetter = (app, ctx) => {
-  const service = {};
-
-  // 儲存instance的暫存，以nameSpace為key值儲存instance
-  // 確保每個ctx階段不會產生兩個同樣service的instance
-  const cache = {};
-
-  // 在相對應的路徑下建立getter，實體化instance時將ctx給予instance
-  Object.entries(app.serviceClasses).forEach(([nameSpace, serviceValue]) => {
-    const scopes = nameSpace.split('.');
-    let myName = scopes[0];
-    // 建立巢狀的object
-    let serviceModule = service;
-    while (scopes.length > 1) {
-      if (!serviceModule[scopes[0]]) serviceModule[scopes[0]] = {};
-      serviceModule = serviceModule[scopes[0]];
-      myName = scopes.shift();
-    }
-
-    // 實作getter，動態回傳service實體
-    const getter = () => {
-      // 判斷serviceValue是否為Class，是的話就new一個instance，否則就直接回傳
-      const serviceType = typeofService(serviceValue);
-      if (serviceType === 'class') {
-        // 確認是否已經有cache，有的話回傳cache
-        if (cache[nameSpace]) return cache[nameSpace];
-        // 如果沒有instance的cache，就new一個service，並儲存到cache裡
-        // eslint-disable-next-line
-        const instance = new serviceValue(ctx);
-        cache[nameSpace] = instance;
-        return instance;
-      }
-      if (serviceType === 'function') {
-        const instance = serviceValue(ctx);
-        return instance;
-      }
-      return serviceValue;
-    };
-
-    Object.defineProperty(serviceModule, myName, { get: getter });
-  });
-  return service;
-};
 /**
  * 將serviceClass儲存在app.serviceClasses中
  * 複寫app.createContext
  */
 const loadToApp = async (modules, app) => {
+  const { BaseContextClass } = global.app.CLASSES;
+
   // 將class儲存到app.serviceClasses裡
   const { serviceClasses } = app;
   await async.eachSeries(modules, async (module) => {
     const loaded = require(module.path);
-    serviceClasses[module.nameSpace] = loaded;
+    // serviceClasses[module.nameSpace] = loaded;
+    serviceClasses.set(module.nameSpace, loaded);
   });
   // 讓app.service可以直接實體化instance(省略eggjs的createAnonymousContext)
-  app.service = serviceGetter(app);
+  app.service = new BaseContextClass(null, serviceClasses);
 
   // override app.createContext，將ctx加上service的getter
   app.createContext = (req, res) => {
@@ -87,7 +36,7 @@ const loadToApp = async (modules, app) => {
     context.originalUrl = request.originalUrl = req.url;
     context.state = {};
 
-    context.service = serviceGetter(app, context);
+    context.service = new BaseContextClass(context, serviceClasses);
     return context;
   };
 };


### PR DESCRIPTION
1. 將原本每次新的ctx階段都要遍尋一次巢狀結構的方式， 重構成使用BaseContextClass不斷對下層結構進行設定getter的方式，
沒有被存取到的Service不會觸發getter，以強化運作效率。

2. 移除function帶入ctx的方式編寫Service，因為可能會導致function被誤觸造成side effect。

3. 使用Object編寫Service的話現在可以用Object.defineProperty的方式對instance進行methods/properties的擴充，藉此Object的編寫方式也可以存取到this.ctx。