### PR TITLE
fix: application extend的 to.email()判斷出錯的問題 #22

### DIFF
--- a/app/extend/utils/is.js
+++ b/app/extend/utils/is.js
@@ -118,7 +118,7 @@ is.primitive = (target) => target === null
  * 從 https://github.com/manishsaraan/email-validator 複製過來
  */
 is.email = (target) => {
-  const tester = /^[-!#$%&'*+/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
+  const tester = /^[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
   if (!is.string(target)) return false;
 
   const emailParts = target.split('@');


### PR DESCRIPTION
1. is.email裡的regexp少了幾個 \ ，重新補上正確的regexp

issue: #22