### PR TITLE
feat: 調整schedule與router的載入方式

### DIFF
--- a/lib/class/mahudas_class.js
+++ b/lib/class/mahudas_class.js
@@ -53,6 +53,7 @@ class Mahudas extends Koa {
 
     this.router = new Router();
     this.controller = {};
+    this.schedule = {};
 
     this.CLASSES = {
       BaseContext,
@@ -82,6 +83,8 @@ class Mahudas extends Koa {
     appContainer.loadMiddleware();
     appContainer.loadController();
     appContainer.loadRouter();
+
+    appContainer.loadSchedule();
 
     // 結構載入完成，發送並等待didLoad事件
     // 讓其他plugin有時間在主機啟動前有機會進行介入
@@ -113,8 +116,6 @@ class Mahudas extends Koa {
     console.log('\x1B[36m▉ Memory usage:\x1B[0m', memoryInfo);
 
     this.emit('serverDidReady');
-
-    this.mainApp.loadSchedule();
   }
 
   getAppStructure() {

--- a/lib/loader/mixin/controller.js
+++ b/lib/loader/mixin/controller.js
@@ -12,17 +12,13 @@ const recursiveInject = (modules, app) => {
 
   modules.forEach((module) => {
     const splitName = module.nameSpace.split('.');
-    if (splitName.length) {
-      splitName.reduce((r, a, currentIndex) => {
-        r[a] = r[a] || {};
-        if (splitName.length === currentIndex + 1) {
-          r[a] = require(module.path);
-        }
-        return r[a];
-      }, controller);
-    } else {
-      controller[module.nameSpace] = require(module.path);
-    }
+    splitName.reduce((r, a, currentIndex) => {
+      r[a] = r[a] || {};
+      if (splitName.length === currentIndex + 1) {
+        r[a] = require(module.path);
+      }
+      return r[a];
+    }, controller);
   });
 };
 

--- a/lib/loader/mixin/router.js
+++ b/lib/loader/mixin/router.js
@@ -1,22 +1,12 @@
 /* eslint global-require:0, import/no-dynamic-require:0 */
 const path = require('path');
-
-/**
- * 利用recursiveSearch得到的物件
- * 載入模組並注入到app相對應的變數中
- */
-const recursiveInject = (modules, app) => {
-  if (modules.length === 0) return;
-
-  modules.forEach((module) => {
-    require(module.path)(app);
-  });
-};
+const fs = require('fs');
 
 module.exports = {
   loadRouter(startPath) {
-    const scanPath = path.join(startPath || this.app.appInfo.root, 'app', 'router');
-    const modules = this.recursiveSearch(scanPath);
-    recursiveInject(modules, this.app);
+    const filePath = path.join(startPath || this.app.appInfo.root, 'app', 'router', 'index.js');
+    if (fs.existsSync(filePath)) {
+      require(filePath)(this.app);
+    }
   },
 };

--- a/lib/loader/mixin/schedule.js
+++ b/lib/loader/mixin/schedule.js
@@ -3,28 +3,40 @@
 const path = require('path');
 const ScheduleJob = require('../../class/schedule_job_class');
 
-const loadToApp = (modules, app) => {
+/**
+ * 利用recursiveSearch得到的物件
+ * 載入模組並注入到app相對應的變數中
+ */
+const recursiveInject = (modules, app) => {
+  if (modules.length === 0) return;
+  const { schedule } = app;
   const { is, to } = app.utils;
-  app.schedule = {};
+
   modules.forEach((module) => {
-    const required = require(module.path);
-    let enable = true;
+    const splitName = module.nameSpace.split('.');
+    splitName.reduce((r, a, currentIndex) => {
+      r[a] = r[a] || {};
+      if (splitName.length === currentIndex + 1) {
+        const required = require(module.path);
+        let enable = true;
+        if (required.schedule.enable !== undefined) {
+          enable = to.boolean(required.schedule.enable);
+        }
 
-    if (required.schedule.enable !== undefined) {
-      enable = to.boolean(required.schedule.enable);
-    }
+        if (enable && required.schedule.env) {
+          if (is.string(required.schedule.env)) {
+            enable = required.schedule.env === process.env.APP_ENV;
+          } else if (is.array(required.schedule.env)) {
+            enable = required.schedule.env.includes(process.env.APP_ENV);
+          }
+        }
 
-    if (enable && required.schedule.env) {
-      if (is.string(required.schedule.env)) {
-        enable = required.schedule.env === process.env.APP_ENV;
-      } else if (is.array(required.schedule.env)) {
-        enable = required.schedule.env.includes(process.env.APP_ENV);
+        if (enable) {
+          r[a] = new ScheduleJob(required.schedule, required.task, app);
+        }
       }
-    }
-
-    if (!enable) return;
-
-    app.schedule[module.nameSpace] = new ScheduleJob(required.schedule, required.task, app);
+      return r[a];
+    }, schedule);
   });
 };
 
@@ -33,6 +45,6 @@ module.exports = {
     const scanPath = path.join(startPath || this.app.appInfo.root, 'app', 'schedule');
     const modules = this.recursiveSearch(scanPath);
 
-    loadToApp(modules, this.app);
+    recursiveInject(modules, this.app);
   },
 };


### PR DESCRIPTION
1. 將router改成只載入 /app/router/index.js 這個檔。
2. 將schedule的載入改成跟controller一樣，允許巢狀結構。
3. 調整 controller 的 loader，if (splitName.length) 或永遠是true，不會有else。
4. 將loadSchedule的時間改到發送didLoad事件之前，讓開發者可以在didLoad事件被觸發時就可以取得schedule的控制權。

issue #24 #28