### PR TITLE
fix: app.js如果在被require時就出錯，Mahudas不會捕捉錯誤的問題

### DIFF
--- a/lib/class/app_container_class.js
+++ b/lib/class/app_container_class.js
@@ -36,12 +36,9 @@ class AppContainer {
       }
     }
     // 試著載入application根目錄之下的app.js
-    // 因為app.js可以允許不存在，因此用try...catch包起來
-    try {
-      if (fs.existsSync(path.join(rootPath, 'app.js'))) {
-        require(path.join(rootPath, 'app.js'))(app);
-      }
-    } catch (e) { /** */ }
+    if (fs.existsSync(path.join(rootPath, 'app.js'))) {
+      require(path.join(rootPath, 'app.js'))(app);
+    }
 
     this.findPlugins();
   }


### PR DESCRIPTION
AppContainer裡在require app.js的地方，將try-catch拿掉。
讓錯誤可以順利的拋出到最外層。

issue #39