### PR TITLE
fix: service、controller... 這些目錄如果存在非js檔的檔案會出錯 #41

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -58,6 +58,7 @@ class Loader {
           const subModules = this.recursiveSearch(startPath, path.join(subPath, dirent.name));
           modules = [...modules, ...subModules];
         } else {
+          if (!/\.js$/.test(dirent.name)) return;
           modules.push({
             nameSpace: this.pathToCamelCase(currentPath, startPath),
             path: currentPath,


### PR DESCRIPTION
在loader的recursiveSearch function裡進行regex的判斷，非js檔就忽略

issue #41