### PR TITLE
支援從config 設定要載入全站router 的middleware

### DIFF
--- a/lib/class/app_container_class.js
+++ b/lib/class/app_container_class.js
@@ -136,9 +136,9 @@ class AppContainer {
 
   loadMiddleware() {
     this.subApps.forEach((subApp) => {
-      subApp.loadMiddleware();
+      subApp.loadMiddleware(subApp.isMainApp);
     });
-    this.loader.loadMiddleware(this.rootPath);
+    this.loader.loadMiddleware(this.isMainApp, this.rootPath);
   }
 
   // controller及router只有在主應用才會生效

--- a/lib/class/app_container_class.js
+++ b/lib/class/app_container_class.js
@@ -136,9 +136,23 @@ class AppContainer {
 
   loadMiddleware() {
     this.subApps.forEach((subApp) => {
-      subApp.loadMiddleware(subApp.isMainApp);
+      subApp.loadMiddleware();
     });
-    this.loader.loadMiddleware(this.isMainApp, this.rootPath);
+    this.loader.loadMiddleware(this.rootPath);
+
+    // 從 config 載入全站 router 要用的 middleware
+    const { app } = this;
+    const { is } = app.utils;
+    if (this.isMainApp && app.config.middleware && is.array(app.config.middleware)) {
+      app.config.middleware.forEach((name) => {
+        if (app.middleware[name]) {
+          app.use(app.middleware[name]);
+          app.coreLogger.info(`\x1B[36m▉ Used Global Middleware:\x1B[34m ${name}\x1B[0m`);
+        } else {
+          app.coreLogger.warn(`\x1B[33m▉ Not Found Global Middleware:\x1B[34m ${name}\x1B[0m (be ignored)`);
+        }
+      });
+    }
   }
 
   // controller及router只有在主應用才會生效

--- a/lib/loader/mixin/middleware.js
+++ b/lib/loader/mixin/middleware.js
@@ -29,10 +29,24 @@ const recursiveInject = (modules, app) => {
   });
 };
 
+const useGlobalMiddleware = (app, isMainApp) => {
+  if (isMainApp && Object.prototype.hasOwnProperty.call(app.config, 'middleware') && app.utils.is.array(app.config.middleware)) {
+    app.config.middleware.forEach((name) => {
+      if (Object.prototype.hasOwnProperty.call(app.middleware, name)) {
+        app.use(app.middleware[name]);
+        app.coreLogger.info(`\x1B[36m▉ Used Global Middleware:\x1B[34m ${name}\x1B[0m`);
+      } else {
+        app.coreLogger.warn(`\x1B[31m▉ Not Found Global Middleware:\x1B[34m ${name}\x1B[0m (be ignored)`);
+      }
+    });
+  }
+};
+
 module.exports = {
-  loadMiddleware(startPath) {
+  loadMiddleware(isMainApp, startPath) {
     const scanPath = path.join(startPath || this.app.appInfo.root, 'app', 'middleware');
     const modules = this.recursiveSearch(scanPath);
     recursiveInject(modules, this.app);
+    useGlobalMiddleware(this.app, isMainApp);
   },
 };

--- a/lib/loader/mixin/middleware.js
+++ b/lib/loader/mixin/middleware.js
@@ -29,24 +29,10 @@ const recursiveInject = (modules, app) => {
   });
 };
 
-const useGlobalMiddleware = (app, isMainApp) => {
-  if (isMainApp && Object.prototype.hasOwnProperty.call(app.config, 'middleware') && app.utils.is.array(app.config.middleware)) {
-    app.config.middleware.forEach((name) => {
-      if (Object.prototype.hasOwnProperty.call(app.middleware, name)) {
-        app.use(app.middleware[name]);
-        app.coreLogger.info(`\x1B[36m▉ Used Global Middleware:\x1B[34m ${name}\x1B[0m`);
-      } else {
-        app.coreLogger.warn(`\x1B[31m▉ Not Found Global Middleware:\x1B[34m ${name}\x1B[0m (be ignored)`);
-      }
-    });
-  }
-};
-
 module.exports = {
-  loadMiddleware(isMainApp, startPath) {
+  loadMiddleware(startPath) {
     const scanPath = path.join(startPath || this.app.appInfo.root, 'app', 'middleware');
     const modules = this.recursiveSearch(scanPath);
     recursiveInject(modules, this.app);
-    useGlobalMiddleware(this.app, isMainApp);
   },
 };


### PR DESCRIPTION
因為把捕獲網站所有的錯誤寫在 middleware 來處理
目前在Router 沒有好方法可以方便設置
所以從config 多設制了一個 middleware 參數
再啟動 server時，就先載入就不用再特別設定

範例
----
> config.defalut.js
```js
config = {
...
middleware: ['error'], // 在middleware 資料夾下的檔名
...
}
```